### PR TITLE
fix crash on missing target_prefix in extension Makefile

### DIFF
--- a/lib/echoe.rb
+++ b/lib/echoe.rb
@@ -173,7 +173,7 @@ class Echoe
     self.test_pattern = File.exist?("test/test_all.rb") ? "test/test_all.rb" : ['test/**/test_*.rb', 'test/**/*_test.rb']
     self.spec_pattern = "spec/**/*_spec.rb"
 
-    self.ignore_pattern = /^(pkg|doc)|\.svn|CVS|\.bzr|\.DS|\.git/
+    self.ignore_pattern = /^(pkg|doc)|(\.svn|CVS|\.bzr|\.DS|\.git)$/
 
     self.changelog_patterns = {
         :version => [


### PR DESCRIPTION
If an extension's Makefile is not generated by mkmf, it doesn't necessarily have a "target_prefix" line.

If this line isn't present it caused echoe to crash with a ruby exception.
