### PR TITLE
Rubyforge project URL optional

### DIFF
--- a/lib/echoe.rb
+++ b/lib/echoe.rb
@@ -352,7 +352,7 @@ private
       s.author = Array(author).join(", ")
       s.email = email
       s.homepage = url
-      s.rubyforge_project = project
+      s.rubyforge_project = project if project
       s.post_install_message = install_message if install_message
       s.description = description
       s.required_ruby_version = ruby_version


### PR DESCRIPTION
This is my pull request for make Rubyforge project URL optional, as I asked [here](https://github.com/fauna/echoe/issues/14).
