### PR TITLE
optionally include dotfiles in the manifest

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v4.7.0. Add config option to include dotfiles when building the manifest. Defaults to off to perserve backwards compatibility. The option is `use_git_ls_files`
+
 v4.6.6. Fix bug with unclosed Manifest file.
 
 v4.6.5. Gem public cert.

--- a/echoe.gemspec
+++ b/echoe.gemspec
@@ -1,45 +1,43 @@
 # -*- encoding: utf-8 -*-
-# stub: echoe 4.6.6 ruby lib
+# stub: echoe 4.7.0 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "echoe"
-  s.version = "4.6.6"
+  s.name = "echoe".freeze
+  s.version = "4.7.0"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 1.8.4") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Evan Weaver"]
-  s.cert_chain = ["/Users/eweaver/cloudburst/github/echoe/echoe.pem"]
-  s.date = "2014-05-15"
-  s.description = "A Rubygems packaging tool that provides Rake tasks for documentation, extension compiling, testing, and deployment."
-  s.email = ""
-  s.extra_rdoc_files = ["CHANGELOG", "LICENSE", "README.rdoc", "lib/echoe.rb", "lib/echoe/extensions.rb", "lib/echoe/platform.rb", "lib/echoe/rubygems.rb"]
-  s.files = ["CHANGELOG", "LICENSE", "MIT-LICENSE", "Manifest", "README.rdoc", "Rakefile", "echoe.gemspec", "echoe.pem", "lib/echoe.rb", "lib/echoe/extensions.rb", "lib/echoe/platform.rb", "lib/echoe/rubygems.rb", "vendor/rake/MIT-LICENSE", "vendor/rake/lib/rake/contrib/compositepublisher.rb", "vendor/rake/lib/rake/contrib/ftptools.rb", "vendor/rake/lib/rake/contrib/publisher.rb", "vendor/rake/lib/rake/contrib/rubyforgepublisher.rb", "vendor/rake/lib/rake/contrib/sshpublisher.rb", "vendor/rake/lib/rake/contrib/sys.rb"]
-  s.homepage = "http://fauna.github.com/fauna/echoe/"
-  s.licenses = ["Academic Free License (AFL) v. 3.0"]
-  s.rdoc_options = ["--line-numbers", "--title", "Echoe", "--main", "README.rdoc"]
-  s.require_paths = ["lib"]
-  s.rubyforge_project = "fauna"
-  s.rubygems_version = "2.1.10"
-  s.signing_key = "/Users/eweaver/cloudburst/configuration/gem_certificates/gem-private_key.pem"
-  s.summary = "A Rubygems packaging tool that provides Rake tasks for documentation, extension compiling, testing, and deployment."
+  s.required_rubygems_version = Gem::Requirement.new(">= 1.8.4".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Evan Weaver".freeze]
+  s.date = "2017-09-26"
+  s.description = "A Rubygems packaging tool that provides Rake tasks for documentation, extension compiling, testing, and deployment.".freeze
+  s.email = "".freeze
+  s.extra_rdoc_files = ["CHANGELOG".freeze, "LICENSE".freeze, "README.rdoc".freeze, "lib/echoe.rb".freeze, "lib/echoe/extensions.rb".freeze, "lib/echoe/platform.rb".freeze, "lib/echoe/rubygems.rb".freeze]
+  s.files = ["CHANGELOG".freeze, "LICENSE".freeze, "MIT-LICENSE".freeze, "Manifest".freeze, "README.rdoc".freeze, "Rakefile".freeze, "echoe.gemspec".freeze, "echoe.pem".freeze, "lib/echoe.rb".freeze, "lib/echoe/extensions.rb".freeze, "lib/echoe/platform.rb".freeze, "lib/echoe/rubygems.rb".freeze, "vendor/rake/MIT-LICENSE".freeze, "vendor/rake/lib/rake/contrib/compositepublisher.rb".freeze, "vendor/rake/lib/rake/contrib/ftptools.rb".freeze, "vendor/rake/lib/rake/contrib/publisher.rb".freeze, "vendor/rake/lib/rake/contrib/rubyforgepublisher.rb".freeze, "vendor/rake/lib/rake/contrib/sshpublisher.rb".freeze, "vendor/rake/lib/rake/contrib/sys.rb".freeze]
+  s.homepage = "http://fauna.github.com/fauna/echoe/".freeze
+  s.licenses = ["Academic Free License (AFL) v. 3.0".freeze]
+  s.rdoc_options = ["--line-numbers".freeze, "--title".freeze, "Echoe".freeze, "--main".freeze, "README.rdoc".freeze]
+  s.rubyforge_project = "fauna".freeze
+  s.rubygems_version = "2.6.11".freeze
+  s.summary = "A Rubygems packaging tool that provides Rake tasks for documentation, extension compiling, testing, and deployment.".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rubyforge>, [">= 2.0.4"])
-      s.add_runtime_dependency(%q<allison>, [">= 2.0.3"])
-      s.add_runtime_dependency(%q<rdoc>, [">= 2.5.11"])
-      s.add_runtime_dependency(%q<rake>, [">= 0.9.2"])
+      s.add_runtime_dependency(%q<rubyforge>.freeze, [">= 2.0.4"])
+      s.add_runtime_dependency(%q<allison>.freeze, [">= 2.0.3"])
+      s.add_runtime_dependency(%q<rdoc>.freeze, [">= 2.5.11"])
+      s.add_runtime_dependency(%q<rake>.freeze, [">= 0.9.2"])
     else
-      s.add_dependency(%q<rubyforge>, [">= 2.0.4"])
-      s.add_dependency(%q<allison>, [">= 2.0.3"])
-      s.add_dependency(%q<rdoc>, [">= 2.5.11"])
-      s.add_dependency(%q<rake>, [">= 0.9.2"])
+      s.add_dependency(%q<rubyforge>.freeze, [">= 2.0.4"])
+      s.add_dependency(%q<allison>.freeze, [">= 2.0.3"])
+      s.add_dependency(%q<rdoc>.freeze, [">= 2.5.11"])
+      s.add_dependency(%q<rake>.freeze, [">= 0.9.2"])
     end
   else
-    s.add_dependency(%q<rubyforge>, [">= 2.0.4"])
-    s.add_dependency(%q<allison>, [">= 2.0.3"])
-    s.add_dependency(%q<rdoc>, [">= 2.5.11"])
-    s.add_dependency(%q<rake>, [">= 0.9.2"])
+    s.add_dependency(%q<rubyforge>.freeze, [">= 2.0.4"])
+    s.add_dependency(%q<allison>.freeze, [">= 2.0.3"])
+    s.add_dependency(%q<rdoc>.freeze, [">= 2.5.11"])
+    s.add_dependency(%q<rake>.freeze, [">= 0.9.2"])
   end
 end


### PR DESCRIPTION
`Dir['**/**']` ignores dotfiles by default; I have a project that needs some dotfiles to be a part of the bundled gem, so I've changed echoe to use
```ruby
`git ls-files -z`.split("\x0").reject do |f|
  f.match(%r{^(test|spec|features)/})
end
```
which is what Bundler generates when you do `bundle gem gem_name`.

To be backwards compatible, there's a config option `use_git_ls_files` that defaults to `false` in which case `Dir['**/.**']` is used; only when `true` is the new code used.